### PR TITLE
CS-3007 Ensure server returns Accepted status code for successfully processed calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ Test locally:
 
 * Open a browser to http://127.0.0.1:8888
 
+To simulate an accepted response:
+* curl -X POST -H "Content-Type: application/json" -d '{"object_id":"0","ts":"..."}' http://localhost:8888/a/callback/ok
+
+To get an echo response:
 * curl -X POST -H "Content-Type: application/json" -d '{"object_id":"0","ts":"..."}' http://localhost:8888/a/callback/echo
 
-
-To simluate a 10 second timeout:
+To simulate a 10 second timeout:
 
 * curl -X POST -H "Content-Type: application/json" -d '{"object_id":"0","ts":"..."}' http://localhost:8888/a/callback/timeout
 
-To simluate an error:
+To simulate an error:
 
 * curl -X POST -H "Content-Type: application/json" -d '{"object_id":"0","ts":"..."}' http://localhost:8888/a/callback/error
 

--- a/server.py
+++ b/server.py
@@ -72,6 +72,15 @@ class CallbackHandler(tornado.web.RequestHandler):
         global_buffer.new_notifications([notification])
 
 
+class CallbackOkHandler(tornado.web.RequestHandler):
+    def check_xsrf_cookie(self):
+        pass
+
+    def post(self):
+        logging.info('Asynchronous processing must be performed here for :%s', self.request.body)
+        self.set_status(202)
+
+
 class CallbackTimeoutHandler(tornado.web.RequestHandler):
     def check_xsrf_cookie(self):
         pass
@@ -115,6 +124,7 @@ if __name__ == "__main__":
         [
             (r"/", MainHandler),
             (r"/a/callback/echo", CallbackHandler),
+            (r"/a/callback/ok", CallbackOkHandler),
             (r"/a/callback/timeout", CallbackTimeoutHandler),
             (r"/a/callback/error", CallbackErrorHandler),
             (r"/a/watch", CallbackWatcher),


### PR DESCRIPTION
- Add new endpoint that returns 202 (Accepted) code, which is required by the webhooks system.
- Processing (as performed in the /echo endpoint) was excluded as it didn't meet the 3 seconds response criteria for webhook clients
